### PR TITLE
Update polling.yaml

### DIFF
--- a/etc/ceilometer/polling.yaml
+++ b/etc/ceilometer/polling.yaml
@@ -3,30 +3,23 @@ sources:
     - name: meter_source
       interval: 600
       meters:
-          - "region*"
-          - "image"
-          - "instance"
-          - "vcpus"
-          - "cpu*"
-          - "memory*"
-          - "disk.usage"
-          - "disk.capacity"
-          - "compute.node.cpu.percent"
-          - "compute.node.cpu.now"
-          - "compute.node.cpu.tot"
-          - "compute.node.cpu.max"
-          - "compute.node.ram.now"
-          - "compute.node.ram.tot"
-          - "compute.node.ram.max"
-          - "compute.node.disk.now"
-          - "compute.node.disk.tot"
-          - "compute.node.disk.max"
-          - "processes.process_pid_count"
-      sinks:
-          - meter_sink
-sinks:
-    - name: meter_sink
-      transformers:
-      publishers:
-          - notifier://
-          - monasca://http://127.0.0.1:8070/v2.0
+        - region*
+        - image
+        - instance
+        - vcpus
+        - cpu*
+        - host*
+        - memory*
+        - disk.usage
+        - disk.capacity
+        - compute.node.cpu.percent
+        - compute.node.cpu.now
+        - compute.node.cpu.tot
+        - compute.node.cpu.max
+        - compute.node.ram.now
+        - compute.node.ram.tot
+        - compute.node.ram.max
+        - compute.node.disk.now
+        - compute.node.disk.tot
+        - compute.node.disk.max
+        - processes.process_pid_count


### PR DESCRIPTION
Fix for #4 
Configuration of "polling.yaml" file is not correct.
Polling.yaml is written same as pipeline .yaml.

Polling.yaml should contain only meters name that will be polled at some fixed interval. There is no need for sink part in polling.yaml, it is required only in pipeline.yaml.
Identation and syntax for meters name is also corrected. (It should not be in quotes)